### PR TITLE
Correctly resizes menubar icon on macOS.

### DIFF
--- a/nct.js
+++ b/nct.js
@@ -8,6 +8,8 @@ const { net } = require('electron');
 const shell = require('electron').shell;
 const util = require('util');
 //const notifier = require('node-notifier');
+const os = require('os');
+const nativeImage = require('electron').nativeImage;
 
 //const electronVersion = require('electron-version')
 //electronVersion(function (err, v) {
@@ -187,8 +189,18 @@ function sendToTray(status) {
 	}	else {
 		iconPath = path.join(__dirname, 'talk1.png');
 	}
+
+	image = nativeImage.createFromPath(iconPath);
+
+	if (os.platform == 'darwin') {
+		image = image.resize({
+			width: 16,
+			height: 16
+		})
+	}
+
 	now = new Date();
-	tray = new Tray(iconPath);
+	tray = new Tray(image);
 	tray.setToolTip('Nextcloud Talk Notifier ' + status + " " + now);
 	const ctxMenu = Menu.buildFromTemplate(trayMenuTemplate);
 	tray.setContextMenu(ctxMenu);


### PR DESCRIPTION
When running the app on macOS the menubar icon is way too big. This pull request resizes the image if needed.

Before: 
<img width="383" alt="before" src="https://user-images.githubusercontent.com/7619937/82360748-1f145c80-9a0a-11ea-81b1-135b67916ab8.png">

After:
<img width="167" alt="after" src="https://user-images.githubusercontent.com/7619937/82360765-25a2d400-9a0a-11ea-937f-f402e569a564.png">